### PR TITLE
[Not to merge] Add InMemoryTransport abstraction

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -157,12 +157,12 @@
   <!-- Versioning properties -->
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">3.0.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)'=='' ">3.6.6</VersionPrefix>
   </PropertyGroup>
 
   <!-- For Debug builds generated a date/time dependent version suffix -->
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
-    <VersionSuffix Condition=" '$(VersionSuffix)'=='' ">dev</VersionSuffix>
+    <VersionSuffix Condition=" '$(VersionSuffix)'=='' ">dev3</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionDateSuffix)'!='' ">$(VersionSuffix)-$(VersionDateSuffix)</VersionSuffix>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -162,7 +162,7 @@
 
   <!-- For Debug builds generated a date/time dependent version suffix -->
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
-    <VersionSuffix Condition=" '$(VersionSuffix)'=='' ">dev3</VersionSuffix>
+    <VersionSuffix Condition=" '$(VersionSuffix)'=='' ">hackathon</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionDateSuffix)'!='' ">$(VersionSuffix)-$(VersionDateSuffix)</VersionSuffix>
   </PropertyGroup>
 

--- a/src/Orleans.Core/Networking/Shared/InMemoryTransportConnection.cs
+++ b/src/Orleans.Core/Networking/Shared/InMemoryTransportConnection.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+using Orleans.Networking.Shared;
+
+
+namespace Orleans.Runtime.Development
+{
+    public class InMemoryTransportConnection : TransportConnection
+    {
+        private readonly CancellationTokenSource _connectionClosedTokenSource = new();
+        private readonly ILogger _logger;
+        private bool _isClosed;
+        private readonly TaskCompletionSource<bool> _waitForCloseTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private InMemoryTransportConnection(MemoryPool<byte> memoryPool, ILogger logger, DuplexPipe.DuplexPipePair pair, EndPoint localEndPoint, EndPoint remoteEndPoint)
+        {
+            MemoryPool = memoryPool;
+            _logger = logger;
+
+            LocalEndPoint = localEndPoint;
+            RemoteEndPoint = remoteEndPoint;
+
+            Application = pair.Application;
+            Transport = pair.Transport;
+
+            ConnectionClosed = _connectionClosedTokenSource.Token;
+        }
+
+        public static InMemoryTransportConnection Create(MemoryPool<byte> memoryPool, ILogger logger, EndPoint localEndPoint, EndPoint remoteEndPoint)
+        {
+            var pair = DuplexPipe.CreateConnectionPair(
+                    new PipeOptions(memoryPool, readerScheduler: PipeScheduler.Inline, useSynchronizationContext: false),
+                    new PipeOptions(memoryPool, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
+            return new InMemoryTransportConnection(memoryPool, logger, pair, localEndPoint, remoteEndPoint);
+        }
+
+        public static InMemoryTransportConnection Create(MemoryPool<byte> memoryPool, ILogger logger, InMemoryTransportConnection other, EndPoint localEndPoint)
+        {
+            // Swap the application & tranport pipes since we're going in the other direction.
+            var pair = new DuplexPipe.DuplexPipePair(transport: other.Application, application: other.Transport);
+            var remoteEndPoint = other.LocalEndPoint;
+            return new InMemoryTransportConnection(memoryPool, logger, pair, localEndPoint, remoteEndPoint);
+        }
+
+        public PipeWriter Input => Application.Output;
+
+        public PipeReader Output => Application.Input;
+
+        public override MemoryPool<byte> MemoryPool { get; }
+
+        public ConnectionAbortedException AbortReason { get; private set; }
+
+        public Task WaitForCloseTask => _waitForCloseTcs.Task;
+
+        public override void Abort(ConnectionAbortedException abortReason)
+        {
+            _logger.LogDebug(@"Connection id ""{ConnectionId}"" closing because: ""{Message}""", ConnectionId, abortReason?.Message);
+
+            Input.Complete(abortReason);
+
+            OnClosed();
+
+            AbortReason = abortReason;
+        }
+
+        public void OnClosed()
+        {
+            if (_isClosed)
+            {
+                return;
+            }
+
+            _isClosed = true;
+            /*
+            ThreadPool.UnsafeQueueUserWorkItem(state =>
+            {
+                state._connectionClosedTokenSource.Cancel();
+
+                state._waitForCloseTcs.TrySetResult(true);
+            },
+            this,
+            preferLocal: false);*/
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            Transport.Input.Complete();
+            Transport.Output.Complete();
+
+            await _waitForCloseTcs.Task;
+
+            _connectionClosedTokenSource.Dispose();
+        }
+    }
+}

--- a/src/Orleans.Core/Networking/Shared/SharedMemoryPool.cs
+++ b/src/Orleans.Core/Networking/Shared/SharedMemoryPool.cs
@@ -2,7 +2,7 @@ using System.Buffers;
 
 namespace Orleans.Networking.Shared
 {
-    internal sealed class SharedMemoryPool
+    public sealed class SharedMemoryPool // NOTE: made this public for testing
     {
         public MemoryPool<byte> Pool { get; } = KestrelMemoryPool.Create();
     }

--- a/src/Orleans.Core/Networking/Shared/TransportConnection.Features.cs
+++ b/src/Orleans.Core/Networking/Shared/TransportConnection.Features.cs
@@ -28,7 +28,7 @@ namespace Orleans.Networking.Shared
         MemoryPool<byte> MemoryPool { get; }
     }
 
-    internal partial class TransportConnection : IConnectionIdFeature,
+    public partial class TransportConnection : IConnectionIdFeature,
                                                  IConnectionTransportFeature,
                                                  IConnectionItemsFeature,
                                                  IMemoryPoolFeature,
@@ -61,7 +61,7 @@ namespace Orleans.Networking.Shared
         void IConnectionLifetimeFeature.Abort() => Abort(new ConnectionAbortedException("The connection was aborted by the application via IConnectionLifetimeFeature.Abort()."));
     }
 
-    internal partial class TransportConnection : IFeatureCollection
+    public partial class TransportConnection : IFeatureCollection
     {
         private static readonly Type IConnectionIdFeatureType = typeof(IConnectionIdFeature);
         private static readonly Type IConnectionTransportFeatureType = typeof(IConnectionTransportFeature);

--- a/src/Orleans.Core/Networking/Shared/TransportConnection.cs
+++ b/src/Orleans.Core/Networking/Shared/TransportConnection.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Http.Features;
 
 namespace Orleans.Networking.Shared
 {
-    internal abstract partial class TransportConnection : ConnectionContext
+    public abstract partial class TransportConnection : ConnectionContext
     {
         private IDictionary<object, object> _items;
         private string _connectionId;

--- a/src/Orleans.Runtime/Hosting/InMemoryTransportExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/InMemoryTransportExtensions.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans.Hosting;
+using Orleans.Internal;
+using Orleans.Networking.Shared;
+using Orleans.Runtime;
+using Orleans.Runtime.Development;
+using Orleans.Runtime.Messaging;
+
+namespace Orleans.TestingHost.InMemoryTransport;
+
+public static class InMemoryTransportExtensions
+{
+    public static ISiloBuilder UseInMemoryConnectionTransport(this ISiloBuilder siloBuilder, InMemoryTransportConnectionHub hub)
+    {
+        siloBuilder.ConfigureServices(services =>
+        {
+            services.AddSingletonKeyedService<object, IConnectionFactory>(SiloConnectionFactory.ServicesKey, CreateInMemoryConnectionFactory(hub));
+            services.AddSingletonKeyedService<object, IConnectionListenerFactory>(SiloConnectionListener.ServicesKey, CreateInMemoryConnectionListenerFactory(hub));
+            services.AddSingletonKeyedService<object, IConnectionListenerFactory>(GatewayConnectionListener.ServicesKey, CreateInMemoryConnectionListenerFactory(hub));
+        });
+
+        return siloBuilder;
+    }
+
+    public static IClientBuilder UseInMemoryConnectionTransport(this IClientBuilder clientBuilder, InMemoryTransportConnectionHub hub)
+    {
+        clientBuilder.ConfigureServices(services =>
+        {
+            services.AddSingletonKeyedService<object, IConnectionFactory>(ClientOutboundConnectionFactory.ServicesKey, CreateInMemoryConnectionFactory(hub));
+        });
+
+        return clientBuilder;
+    }
+
+    private static Func<IServiceProvider, object, IConnectionFactory> CreateInMemoryConnectionFactory(InMemoryTransportConnectionHub hub)
+    {
+        return (IServiceProvider sp, object key) =>
+        {
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            var sharedMemoryPool = sp.GetRequiredService<SharedMemoryPool>();
+            return new InMemoryTransportConnectionFactory(hub, loggerFactory, sharedMemoryPool);
+        };
+    }
+
+    private static Func<IServiceProvider, object, IConnectionListenerFactory> CreateInMemoryConnectionListenerFactory(InMemoryTransportConnectionHub hub)
+    {
+        return (IServiceProvider sp, object key) =>
+        {
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            var sharedMemoryPool = sp.GetRequiredService<SharedMemoryPool>();
+            return new InMemoryTransportListener(hub, loggerFactory, sharedMemoryPool);
+        };
+    }
+}
+
+public class InMemoryTransportListener : IConnectionListenerFactory, IConnectionListener
+{
+    private readonly Channel<(InMemoryTransportConnection Connection, TaskCompletionSource<bool> ConnectionAcceptedTcs)> _acceptQueue = Channel.CreateUnbounded<(InMemoryTransportConnection, TaskCompletionSource<bool>)>();
+    private readonly InMemoryTransportConnectionHub _hub;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly SharedMemoryPool _memoryPool;
+    private readonly CancellationTokenSource _disposedCts = new();
+
+    public InMemoryTransportListener(InMemoryTransportConnectionHub hub, ILoggerFactory loggerFactory, SharedMemoryPool memoryPool)
+    {
+        _hub = hub;
+        _loggerFactory = loggerFactory;
+        _memoryPool = memoryPool;
+    }
+
+    public CancellationToken OnDisposed => _disposedCts.Token;
+
+    public EndPoint EndPoint { get; set; }
+
+    public async Task ConnectAsync(InMemoryTransportConnection connection)
+    {
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (_acceptQueue.Writer.TryWrite((connection, completion)))
+        {
+            var connected = await completion.Task;
+            if (connected)
+            {
+                return;
+            }
+        }
+
+        throw new ConnectionFailedException($"Unable to connect to {EndPoint} because its listener has terminated.");
+    }
+
+    public async ValueTask<ConnectionContext> AcceptAsync(CancellationToken cancellationToken = default)
+    {
+        if (await _acceptQueue.Reader.WaitToReadAsync(cancellationToken))
+        {
+            if (_acceptQueue.Reader.TryRead(out var item))
+            {
+                var remoteConnectionContext = item.Connection;
+                var localConnectionContext = InMemoryTransportConnection.Create(
+                    _memoryPool.Pool,
+                    _loggerFactory.CreateLogger<InMemoryTransportConnection>(),
+                    other: remoteConnectionContext,
+                    localEndPoint: EndPoint);
+
+                // Set the result to true to indicate that the connection was accepted.
+                item.ConnectionAcceptedTcs.TrySetResult(true);
+
+                return localConnectionContext;
+            }
+        }
+
+        return null;
+    }
+
+    public ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
+    {
+        EndPoint = endpoint;
+        _hub.RegisterConnectionListenerFactory(endpoint, this);
+        return new ValueTask<IConnectionListener>(this);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return UnbindAsync(default);
+    }
+
+    public ValueTask UnbindAsync(CancellationToken cancellationToken = default)
+    {
+        _acceptQueue.Writer.TryComplete();
+        while (_acceptQueue.Reader.TryRead(out var item))
+        {
+            // Set the result to false to indicate that the listener has terminated.
+            item.ConnectionAcceptedTcs.TrySetResult(false);
+        }
+
+        _disposedCts.Cancel();
+        return default;
+    }
+}
+
+public class InMemoryTransportConnectionHub
+{
+    private readonly ConcurrentDictionary<EndPoint, InMemoryTransportListener> _listeners = new();
+
+    public static InMemoryTransportConnectionHub Instance { get; } = new();
+
+    public void RegisterConnectionListenerFactory(EndPoint endPoint, InMemoryTransportListener listener)
+    {
+        _listeners[endPoint] = listener;
+        listener.OnDisposed.Register(() =>
+        {
+            ((IDictionary<EndPoint, InMemoryTransportListener>)_listeners).Remove(new KeyValuePair<EndPoint, InMemoryTransportListener>(endPoint, listener));
+        });
+    }
+
+    public InMemoryTransportListener GetConnectionListenerFactory(EndPoint endPoint)
+    {
+        _listeners.TryGetValue(endPoint, out var listener);
+        return listener;
+    }
+}
+
+public class InMemoryTransportConnectionFactory : IConnectionFactory
+{
+    private readonly InMemoryTransportConnectionHub _hub;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly SharedMemoryPool _memoryPool;
+    private readonly IPEndPoint _localEndpoint;
+
+    internal InMemoryTransportConnectionFactory(InMemoryTransportConnectionHub hub, ILoggerFactory loggerFactory, SharedMemoryPool memoryPool)
+    {
+        _hub = hub;
+        _loggerFactory = loggerFactory;
+        _memoryPool = memoryPool;
+        var myRng = new Random();
+        _localEndpoint = new IPEndPoint(IPAddress.Loopback, myRng.Next(1024, ushort.MaxValue - 1024));
+    }
+
+    public async ValueTask<ConnectionContext> ConnectAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
+    {
+        var listener = _hub.GetConnectionListenerFactory(endpoint);
+        if (listener is null)
+        {
+            throw new ConnectionFailedException($"Unable to connect to endpoint {endpoint} because no such endpoint is currently registered.");
+        }
+
+        var connectionContext = InMemoryTransportConnection.Create(
+            _memoryPool.Pool,
+            _loggerFactory.CreateLogger<InMemoryTransportConnection>(),
+            _localEndpoint,
+            endpoint);
+        await listener.ConnectAsync(connectionContext).WithCancellation(cancellationToken);
+        return connectionContext;
+    }
+}
+

--- a/src/Orleans.Runtime/Hosting/InMemoryTransportExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/InMemoryTransportExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Orleans.Hosting;
 using Orleans.Internal;
@@ -21,6 +22,7 @@ public static class InMemoryTransportExtensions
 {
     public static ISiloBuilder UseInMemoryConnectionTransport(this ISiloBuilder siloBuilder, InMemoryTransportConnectionHub hub)
     {
+        Console.WriteLine(":: UseInMemoryConnectiontTransport NEW");
         siloBuilder.ConfigureServices(services =>
         {
             services.AddSingletonKeyedService<object, IConnectionFactory>(SiloConnectionFactory.ServicesKey, CreateInMemoryConnectionFactory(hub));
@@ -83,6 +85,7 @@ public class InMemoryTransportListener : IConnectionListenerFactory, IConnection
 
     public async Task ConnectAsync(InMemoryTransportConnection connection)
     {
+        Console.WriteLine(":: ConnectAsync");
         var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         if (_acceptQueue.Writer.TryWrite((connection, completion)))
         {
@@ -98,6 +101,7 @@ public class InMemoryTransportListener : IConnectionListenerFactory, IConnection
 
     public async ValueTask<ConnectionContext> AcceptAsync(CancellationToken cancellationToken = default)
     {
+        Console.WriteLine(":: AcceptAsync");
         if (await _acceptQueue.Reader.WaitToReadAsync(cancellationToken))
         {
             if (_acceptQueue.Reader.TryRead(out var item))
@@ -121,6 +125,7 @@ public class InMemoryTransportListener : IConnectionListenerFactory, IConnection
 
     public ValueTask<IConnectionListener> BindAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
     {
+        Console.WriteLine(":: BindAsync");
         EndPoint = endpoint;
         _hub.RegisterConnectionListenerFactory(endpoint, this);
         return new ValueTask<IConnectionListener>(this);
@@ -185,6 +190,7 @@ public class InMemoryTransportConnectionFactory : IConnectionFactory
 
     public async ValueTask<ConnectionContext> ConnectAsync(EndPoint endpoint, CancellationToken cancellationToken = default)
     {
+        Console.WriteLine(":: ConnectAsync");
         var listener = _hub.GetConnectionListenerFactory(endpoint);
         if (listener is null)
         {


### PR DESCRIPTION
This PR has been opened for discussion purposes only. It shows our port of [InMemoryTransportListenerFactory](https://github.com/dotnet/orleans/blob/d92c2050b4c51fdd8243a4e67947de945af9d0ae/src/Orleans.TestingHost/InMemoryTransport/InMemoryTransportListenerFactory.cs) and [InMemoryTransportConnection](https://github.com/dotnet/orleans/blob/1c0ee4370d540547e6070c4caa71c50baf45d441/src/Orleans.TestingHost/InMemoryTransport/InMemoryTransportConnection.cs) to a fork of Orleans v3.6.1